### PR TITLE
feat : Add PDF support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ mobiles for example.
 ## Requirements
 
 - Pillow >= 2.8
+- ghostscript installed on your machine (gs command available)
+- imagemagick installed on your machine (convert command available)
 
 ## Usage
 


### PR DESCRIPTION
Able to convert a PDF file to MBTILES.

Steps:
- Convert each page of the PDF into a PNG
- Combine each PNG to get a single one
- Call the script again to create the tiles