### PR TITLE
feat : Add Docker support using docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM baptwaels/image2mbtiles_dependencies
+
+COPY image2mbtiles.py /usr/src/
+
+ENTRYPOINT [ "python", "image2mbtiles.py" ]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ mobiles for example.
 Syntax:
 
 	$ python image2mbtiles.py source.png output.mbtiles
-	
+
 For example, here is the output of a test:
 
 	$ python image2mbtiles.py 001_Baratta_Vue Naples_BnF.tif output.mbtiles
@@ -69,3 +69,11 @@ You can also manually convert on any other computer:
 Or if needed, you can install requirements and then convert:
 
 	$ fab -H root@1.2.3.4 provision convert:~/Downloads/IMAG0412.png
+
+
+### Docker
+
+You can run the script with Docker using docker-compose
+
+	$ docker-compose build
+	$ docker-compose run image2mbtiles --center 40,40 --meterswidth 10000 --px in.png out.mbtiles

--- a/dependencies/Dockerfile
+++ b/dependencies/Dockerfile
@@ -1,0 +1,14 @@
+FROM python:2.7
+
+# Ghostscript deps
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        ghostscript \
+        imagemagick \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /usr/src/
+WORKDIR /usr/src/
+
+COPY requirements.txt /usr/src/
+RUN pip install -r requirements.txt

--- a/dependencies/requirements.txt
+++ b/dependencies/requirements.txt
@@ -1,0 +1,2 @@
+Pillow
+sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,21 @@
+version: '2'
+
+services:
+
+  image2mbtiles_dependencies:
+    container_name: image2mbtiles_dependencies
+    image: baptwaels/image2mbtiles_dependencies
+    build: ./dependencies
+
+  image2mbtiles:
+    container_name: image2mbtiles
+    image: baptwaels/image2mbtiles
+    build: .
+    volumes:
+      - .:/usr/src/
+    tty: true
+
+volumes:
+  image2mbtiles_data:
+      driver: local
+      


### PR DESCRIPTION
Able to run the entire script within Docker containers. The only requirement is to have Docker and docker-compose installed on your machine

It uses two containers, one for dependencies and the other one to run the script. When modifying the script, no need to rebuild your container since a volume is used. 